### PR TITLE
Fix update manifest package parsing

### DIFF
--- a/.github/workflows/publish-update-manifest.yml
+++ b/.github/workflows/publish-update-manifest.yml
@@ -48,7 +48,10 @@ jobs:
             exit 1
           fi
           package_line="$("$aapt_path" dump badging "$apk_name" | head -n 1)"
-          package_name="$(sed -n "s/.*name='\\([^']*\\)'.*/\\1/p" <<<"$package_line")"
+          # The package line also contains compileSdkVersionCodename='...'.
+          # Anchor this match to the leading package field so a later name=
+          # attribute can never be mistaken for the Android application ID.
+          package_name="$(sed -n "s/^package: name='\\([^']*\\)'.*/\\1/p" <<<"$package_line")"
           version_code="$(sed -n "s/.*versionCode='\\([^']*\\)'.*/\\1/p" <<<"$package_line")"
           version_name="$(sed -n "s/.*versionName='\\([^']*\\)'.*/\\1/p" <<<"$package_line")"
           if [[ "$package_name" != "emu.x360mobile.com" ]]; then


### PR DESCRIPTION
## What changed

Anchors Android application ID extraction to the leading `package: name` field emitted by `aapt dump badging`.

## Why

The previous greedy expression selected the later `compileSdkVersionCodename` field. For the 0.6.0 APK this produced `17` instead of `emu.x360mobile.com`, causing the update-manifest workflow to reject a valid release and leave the public feed empty.

## Validation

Tested against the published `x360-mobile-0.6.0.apk`: the former parser returns `17`; the corrected parser returns `emu.x360mobile.com`. The same inspection confirms `versionName=0.6.0` and `versionCode=6009000`.
